### PR TITLE
Cross browser wheel event handling

### DIFF
--- a/app/spec/panzoom_points.json
+++ b/app/spec/panzoom_points.json
@@ -50,8 +50,9 @@
     {
       "name": "zoom",
       "init": 1.0,
+      "verbose": true,
       "streams": [
-        {"type": "wheel", "expr": "pow(1.001, event.deltaY)"}
+        {"type": "wheel", "expr": "pow(1.001, event.deltaY*pow(16, event.deltaMode))"}
       ]
     },
     {


### PR DESCRIPTION
With the wheel event, deltaX, deltaY and deltaZ can be reported in terms of 3 different modes, depending on the operating system and browser combination. When delta mode is 0, the deltas are pixel values, when delta mode is 1, the deltas are text lines, and when delta mode is 2, they are pages. For me, Firefox was reporting lines instead of pixels. verbose is set to true because the zoom factor on successive wheel events may be the same, but we still want to zoom.
