### PR TITLE
Update vendor script to support linking vega-* dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "scripts": {
     "deploy": "scripts/deploy.sh",
-    "vendor": "npm install && scripts/vendor.sh",
+    "prevendor": "npm install",
+    "vendor": "scripts/vendor.sh",
     "watch": "node scripts/watch.js"
   }
 }

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -3,6 +3,23 @@ ACE=node_modules/ace-builds/src-min
 TARGET=vendor
 DATA=app/data
 
+# Copy dependencies by default. Link if a -l flag is specified.
+CWD=$(pwd)
+VEGA_OP="cp"
+VEGA_DATASETS_OP="cp"
+VEGA_EMBED_OP="cp"
+
+while getopts :l: FLAG; do
+  case $FLAG in
+    l) 
+      echo "Linking '$OPTARG'."
+      npm link $OPTARG
+      OPTARG=$( echo ${OPTARG}_OP | tr '-' '_' | tr '[:lower:]' '[:upper:]' )
+      eval $OPTARG="\"ln -sf\""
+      echo 
+  esac
+done
+
 echo "Copying dependencies to '$TARGET'."
 
 if [ ! -d "$TARGET" ]; then
@@ -13,8 +30,8 @@ cp node_modules/d3/d3.min.js $TARGET
 cp node_modules/d3-cloud/build/d3.layout.cloud.js $TARGET
 cp node_modules/d3-geo-projection/d3.geo.projection.min.js $TARGET
 cp node_modules/topojson/topojson.js $TARGET
-cp node_modules/vega/vega* $TARGET
-cp node_modules/vega-embed/vega-embed* $TARGET
+eval $VEGA_OP "$CWD/node_modules/vega/vega*" $TARGET
+eval $VEGA_EMBED_OP "$CWD/node_modules/vega-embed/vega-embed*" $TARGET
 
 if [ ! -d "$TARGET/ace" ]; then
   mkdir $TARGET/ace
@@ -29,4 +46,4 @@ if [ ! -d "$DATA" ]; then
   mkdir $DATA
 fi
 
-cp node_modules/vega-datasets/data/* $DATA
+eval $VEGA_DATASETS_OP "$CWD/node_modules/vega-datasets/data/*" $DATA


### PR DESCRIPTION
By default, `npm run vendor` continues to copy libraries/datasets to the appropriate folders. However, we can now execute `npm run vendor -- -l vega -l vega-embed -l vega-datasets` and so forth to execute `npm link` and build the necessary symbolic links for us. 
