### PR TITLE
Style adjustment for the middle blank whitespace

### DIFF
--- a/app/editor.css
+++ b/app/editor.css
@@ -3,12 +3,14 @@
   display: flex;
   font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
   font-size: 14px;
+  background-color: #f6f6f6;
 }
 
 .vega-editor .mod_spec {
   -webkit-flex: 0 0 auto;
   flex: 0 0 auto;
   min-width: 540px;
+  border-right: 1px solid #ccc;
 }
 
 .vega-editor .mod_vis {
@@ -16,6 +18,8 @@
   flex: 1 1 auto;
   min-width: 0;
   margin-left: 10px;
+  background-color: white;
+  border-left: 1px solid #ccc;
 }
 
 .vega-editor .module {
@@ -58,6 +62,7 @@
 
 .vega-editor .vis {
   overflow: auto;
+  margin: 4px;
 }
 
 .vega-editor .sel_mode {
@@ -74,7 +79,7 @@
 .vega-editor .spec_desc {
   -webkit-flex: 0 0 auto;
   flex: 0 0 auto;
-  padding-top: 10px;
+  margin: 4px;
   font-size: 12px;
   color: #666;
 }


### PR DESCRIPTION
I feel that the middle whitespace between `.mod_spec` and `.mod_vis` looks a little weird, so I modify it a bit to be nicer. 

**BEFORE (Vega)**:

![vega_editor](https://cloud.githubusercontent.com/assets/111269/10568947/b24507e4-75d3-11e5-9b39-1230bf164c2e.png)

**AFTER (Vega)**:

![vega_editor](https://cloud.githubusercontent.com/assets/111269/10568905/2455a8ee-75d3-11e5-9a00-2384f901911f.png)

---

**BEFORE (Vega-lite)**:

![vega_editor](https://cloud.githubusercontent.com/assets/111269/10568955/e0ec1b3c-75d3-11e5-9109-ce4c07c338b6.png)

**AFTER (Vega-lite)**:

![vega_editor](https://cloud.githubusercontent.com/assets/111269/10568941/94da2f4a-75d3-11e5-8c5d-37309c9384f5.png)
