### PR TITLE
move data to be on the top part of example specs

### DIFF
--- a/app/spec/vega-lite/1d_bar.json
+++ b/app/spec/vega-lite/1d_bar.json
@@ -1,8 +1,8 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "bar",
   "encoding": {
     "x": {"name": "Acceleration","type": "Q","aggregate": "sum"},
     "color": {"name": "Origin","type": "N"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/agg_bar.json
+++ b/app/spec/vega-lite/agg_bar.json
@@ -1,8 +1,8 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "bar",
   "encoding": {
     "x": {"name": "Cylinders","type": "O"},
     "y": {"name": "Acceleration","type": "Q","aggregate": "mean"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/area.json
+++ b/app/spec/vega-lite/area.json
@@ -1,8 +1,8 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "area",
   "encoding": {
     "x": {"name": "Year","type": "T","timeUnit": "year"},
     "y": {"name": "Weight_in_lbs","type": "Q","aggregate": "sum"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/grouped_bar.json
+++ b/app/spec/vega-lite/grouped_bar.json
@@ -1,4 +1,5 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "bar",
   "encoding": {
     "x": {"name": "Origin","type": "N"},
@@ -12,6 +13,5 @@
       "name": "Origin",
       "type": "N"
     }
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/heatmap.json
+++ b/app/spec/vega-lite/heatmap.json
@@ -1,10 +1,11 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "text",
   "encoding": {
     "row": {"name": "Origin","type": "O"},
     "col": {"name": "Cylinders","type": "O"},
     "color": {"name": "Horsepower","type": "Q","aggregate": "mean"},
     "text": {"name": "*","type": "Q","aggregate": "count"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
+
 }

--- a/app/spec/vega-lite/histogram.json
+++ b/app/spec/vega-lite/histogram.json
@@ -1,4 +1,5 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "bar",
   "encoding": {
     "x": {
@@ -7,6 +8,6 @@
       "type": "Q"
     },
     "y": {"name": "*","type": "Q","aggregate": "count"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
+
 }

--- a/app/spec/vega-lite/horsepower.json
+++ b/app/spec/vega-lite/horsepower.json
@@ -1,8 +1,8 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "line",
   "encoding": {
     "x": {"name": "Year","type": "T","timeUnit": "year"},
     "y": {"name": "Horsepower","type": "Q","aggregate": "mean"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/movie_ratings.json
+++ b/app/spec/vega-lite/movie_ratings.json
@@ -1,8 +1,8 @@
 {
+  "data": {"url": "data/movies.json"},
   "marktype": "point",
   "encoding": {
     "x": {"name": "MPAA_Rating","type": "N"},
     "y": {"name": "Release_Date","type": "N"}
-  },
-  "data": {"url": "data/movies.json"}
+  }
 }

--- a/app/spec/vega-lite/scatter.json
+++ b/app/spec/vega-lite/scatter.json
@@ -1,8 +1,8 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "point",
   "encoding": {
     "x": {"name": "Horsepower","type": "Q"},
     "y": {"name": "Miles_per_Gallon","type": "Q"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/stacked_area.json
+++ b/app/spec/vega-lite/stacked_area.json
@@ -1,9 +1,9 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "area",
   "encoding": {
     "x": {"name": "Year","type": "T","timeUnit": "year"},
     "y": {"name": "Weight_in_lbs","type": "Q","aggregate": "sum"},
     "color": {"name": "Cylinders","type": "O"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/stacked_bar.json
+++ b/app/spec/vega-lite/stacked_bar.json
@@ -1,9 +1,9 @@
 {
+  "data": {"url": "data/barley.json"},
   "marktype": "bar",
   "encoding": {
     "x": {"name": "yield","type": "Q","aggregate": "sum"},
     "y": {"name": "variety","type": "N"},
     "color": {"name": "site","type": "N"}
-  },
-  "data": {"url": "data/barley.json"}
+  }
 }

--- a/app/spec/vega-lite/stacked_histogram.json
+++ b/app/spec/vega-lite/stacked_histogram.json
@@ -1,4 +1,5 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "bar",
   "encoding": {
     "x": {
@@ -8,6 +9,5 @@
     },
     "y": {"name": "*","type": "Q","aggregate": "count"},
     "color": {"name": "Cylinders","type": "N"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/trellis_area.json
+++ b/app/spec/vega-lite/trellis_area.json
@@ -1,9 +1,9 @@
 {
+  "data": {"url": "data/cars.json"},
   "marktype": "area",
   "encoding": {
     "x": {"name": "Year","type": "T","timeUnit": "year"},
     "y": {"name": "Weight_in_lbs","type": "Q","aggregate": "sum"},
     "col": {"name": "Cylinders","type": "O"}
-  },
-  "data": {"url": "data/cars.json"}
+  }
 }

--- a/app/spec/vega-lite/trellis_scatter.json
+++ b/app/spec/vega-lite/trellis_scatter.json
@@ -1,13 +1,9 @@
 {
+  "data": {"url": "data/movies.json"},
   "marktype": "point",
   "encoding": {
     "x": {"name": "Worldwide_Gross","type": "Q"},
     "y": {"name": "US_DVD_Sales","type": "Q"},
-    "col": {
-      "axis": {"maxLabelLength": 25},
-      "name": "MPAA_Rating",
-      "type": "O"
-    }
-  },
-  "data": {"url": "data/movies.json"}
+    "col": {"name": "MPAA_Rating","type": "O"}
+  }
 }

--- a/app/spec/vega-lite/trellis_stacked_bar.json
+++ b/app/spec/vega-lite/trellis_stacked_bar.json
@@ -1,10 +1,10 @@
 {
+  "data": {"url": "data/barley.json"},
   "marktype": "bar",
   "encoding": {
     "x": {"name": "yield","type": "Q","aggregate": "sum"},
     "y": {"name": "variety","type": "N"},
     "col": {"name": "year","type": "O"},
     "color": {"name": "site","type": "N"}
-  },
-  "data": {"url": "data/barley.json"}
+  }
 }


### PR DESCRIPTION
- move data to be on the top part of example specs
- also remove unnecessary `maxLabelLength` from `trellis_scatter.json`
