### PR TITLE
Prevent editor to break after first error

### DIFF
--- a/app/editor.js
+++ b/app/editor.js
@@ -239,7 +239,7 @@ ved.parseVg = function(callback) {
 
 ved.resetView = function() {
   var $d3 = ved.$d3;
-  if (ved.view) ved.view.destroy();
+  if (ved.view && ved.view.destroy) ved.view.destroy();
   $d3.select('.mod_params').html('');
   $d3.select('.spec_desc').html('');
   $d3.select('.vis').html('');


### PR DESCRIPTION
If a spec is wrong, `ved.view` becomes an instance of `Error`. The code
trying to execute `ved.view.destroy()` fails, and it becomes impossible
to parse a valid spec again unless one refreshes the HTML page.

Steps to reproduce:
- Open any example of the live editor
- Change the name of the data `table` into `foo`
- Click "Parse" > this generates an error
- Change "foo" back into "table"
- Click "Parse" again: the editor is still broken
