### PR TITLE
Update author credit for health vs income example

### DIFF
--- a/app/spec/vega-lite/bubble_health_income.json
+++ b/app/spec/vega-lite/bubble_health_income.json
@@ -1,5 +1,5 @@
 {
-  "description": "A bubble plot showing the correlation between health and income for 187 countries in the world.",
+  "description": "A bubble plot showing the correlation between health and income for 187 countries in the world (modified from an example in Lisa Charlotte Rost's blog post 'One Chart, Twelve Charting Libraries' --http://lisacharlotterost.github.io/2016/05/17/one-chart-code/).",
   "data": {
     "url": "data/gapminder-health-income.csv",
     "formatType": "csv"


### PR DESCRIPTION
Add author credit in the spec so that the world actually see Lisa's name in the spec description
