### PR TITLE
Set max width and max height for each .vislistitem

### DIFF
--- a/app/editor.css
+++ b/app/editor.css
@@ -235,6 +235,10 @@
   background-color: white;
   border: 1px dashed #ccc;
   margin-right: 2px;
+  max-width: 500px;
+  max-height: 400px;
+  overflow-x: scroll;
+  overflow-y: scroll;
 }
 
 .vislist .itemname {


### PR DESCRIPTION
We are more tolerant with width because with our current examples, cells with big width often have legends on the right. We don't want users to scroll right just to see the legends. We are less tolerant with height because cells with big height are often vertical small multiples for which scrolling is unavoidable, so we don't want tall cells to take up too much screen space. Plus, tall cells will just make the entire row taller, potentially wasting a lot of screen space.
