### PR TITLE
Unregister signals for unused views (for better performance)

### DIFF
--- a/app/editor.js
+++ b/app/editor.js
@@ -317,14 +317,14 @@ function getRankingSummaryText(orderBy, score) {
 * Recursively detach event listeners for all views in a group
 * So the event signals can be garbage-collected when a group exits
 */
-function detachViewsInGroup(root) {
-  if (cql.nest.isSpecQueryModelGroup(root)) { // it's a group
-    root.items.forEach(function(item) {
-      detachViewsInGroup(item);
+function detachViewsInGroup(item) {
+  if (cql.nest.isSpecQueryModelGroup(item)) { // it's a group
+    item.items.forEach(function(childItem) {
+      detachViewsInGroup(childItem);
     });
   }
   else { // it's a SpecQueryModel
-    detachView(root);
+    detachView(item);
   }
 }
 


### PR DESCRIPTION
`ved.cql.views` is a `map`, where the `key` is the `id` for each view (e.g., `vis-0-0-0-2-0`) and the `value` is the `view` object.

I noticed that the view `id` is being re-used, which makes it less ideal for `key`. What's a better key for each view? Do views have globally unique names?
