### PR TITLE
Cyn/router

### DIFF
--- a/src/components/input-panel/spec-editor/renderer.js
+++ b/src/components/input-panel/spec-editor/renderer.js
@@ -48,7 +48,7 @@ export default class Editor extends React.Component {
       this.props.updateVegaLiteSpec(spec);
     }
     if (hashHistory.getCurrentLocation().pathname.indexOf('/edited') === -1) {
-      hashHistory.push('/edited');
+      hashHistory.push(`${this.props.mode}/edited`);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,6 @@ ReactDOM.render(
         <Route path='/:mode/edited' component={App} />
         <Route path='/gist/:vega/:username/:id' component={App} />
         <Route path='/examples/:vega/:example_name' component={App} />
-        <Route path='/examples/:vega/:example_name/edited' component={App} />
       </Router>
     </Provider>
   ),


### PR DESCRIPTION
Editing an example spec goes to '/vega-lite/edited' or 'vega/edited' instead of '/edited'