### PR TITLE
bug fix--Code editor does not load on direct example

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -13,7 +13,8 @@ import { text } from 'd3-request';
 
 class App extends React.Component {
 
-  componentDidMount() {
+  async componentDidMount() {
+    await new Promise(resolve => setTimeout(resolve, 1000));
     window.addEventListener("message", (evt) => {
       var data = evt.data;
       console.log('[Vega-Editor] Received Message', evt.origin, data);
@@ -35,14 +36,7 @@ class App extends React.Component {
       }, 500);
     }, false);
 
-    const parameter = this.props.params;
-    if (parameter.mode && hashHistory.getCurrentLocation().pathname.indexOf('/edited') === -1) {
-       this.props.setMode(parameter.mode);
-    }
-
-    setTimeout(() => {
-      this.setExample(this.props.params);
-    }, 500);
+    this.setExample(this.props.params);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/input-panel/spec-editor/index.js
+++ b/src/components/input-panel/spec-editor/index.js
@@ -8,7 +8,6 @@ const mapStateToProps = function (state, ownProps) {
     mode: state.app.mode,
     selectedExample: state.app.selectedExample,
     gist: state.app.gist,
-    compiledVegaSpec: state.app.compiledVegaSpec,
     autoParse: state.app.autoParse,
     parse: state.app.parse
   };


### PR DESCRIPTION
fixed #146

I'm not sure if this is the best way to fix it. Let me know what you think.
The issue is caused because componentDidMount in app.js is called before monaco editor is mounted, which is odd since componentDidMount should be called after all children components are mounted. 

