### PR TITLE
Added scatterplot using iris data

### DIFF
--- a/spec/vega-lite/scatter_color_opacity_shape.vl.json
+++ b/spec/vega-lite/scatter_color_opacity_shape.vl.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "description": "A scatterplot encoding sepal and petal length differences from 3 different plant species.",
+  "data": {"url": "data/iris.json"},
+  "mark": "point",
+  "encoding": {
+    "x": {
+      "field": "sepalLength",
+      "type": "quantitative",
+      "scale": {"zero": false},
+      "axis": {"title": "sepal length"}
+    },
+    "y": {"field": "petalLength", "type": "quantitative",
+        "axis": {"title": "petal length"}
+    },
+    "color": {"field": "species", "type": "nominal"},
+    "opacity": {"field": "species", "type": "nominal"},
+    "shape": {"field": "species", "type": "nominal"}
+  }
+}


### PR DESCRIPTION
I've added a scatter plot using the iris dataset, encoding several retinal properties on the species, comparing sepal and petal length.

I've tried my best to follow the conventions in the guide here: 
https://docs.google.com/document/d/1u1T9HOTXABqusSX-n6aM8FSsXdhTnrdlaZ-pzNInNik/edit#

Please let me know if there is any issue, I'm happy to correct it.