### PR TITLE
don't show compiled spec by default

### DIFF
--- a/src/reducers/app/index.js
+++ b/src/reducers/app/index.js
@@ -28,7 +28,7 @@ export default (state = {
         vegaLiteSpec: {},
         selectedExample: null,
         editorString: '{}',
-        compiledVegaSpec: {},
+        compiledVegaSpec: false,
         gist: null,
         parse: false
       });


### PR DESCRIPTION
this prevents the compiled display from opening automatically when you navigate to a url like https://vega.github.io/editor/#/examples/vega-lite/bar